### PR TITLE
ntuple(n, identity) becomes tuple(collect(1:n)...)

### DIFF
--- a/src/Options.jl
+++ b/src/Options.jl
@@ -38,7 +38,7 @@ function Options{T<:OptionsChecking}(::Type{T},args...)
     end
     n = div(length(args),2)
     keys, index, vals = if n > 0
-        (args[1:2:end], ntuple(n, identity), Any[args[2:2:end]...])
+        (args[1:2:end], tuple(collect(1:n)...), Any[args[2:2:end]...])
     else
         ((), (), Array(Any, 0))
     end


### PR DESCRIPTION
This came up as a fix to the deprecation warning of ```ntuple(n::Integer, f::Function)``` — see https://github.com/JuliaLang/julia/pull/11486, in favor of ```ntuple(f, n)```. But actually, in the special case of ```f``` being the identity (i.e. we merely want to build ```(1, 2, .... n)```), calling ```tuple(collect(1:n)...)``` has the same result and runs always faster on my MacBook. It allocates 2x-4x less memory and runs 1.5x-10x faster. Also, the LLVM code has 2 lines instead of 20.

What do you think ? Is there are reason why ```ntuple(identity, n)``` should be preferred over ```tuple(collect(1:n)...)```?