### PR TITLE
Get rid of ntuple warnings on Julia 0.4-x

### DIFF
--- a/src/Options.jl
+++ b/src/Options.jl
@@ -38,7 +38,7 @@ function Options{T<:OptionsChecking}(::Type{T},args...)
     end
     n = div(length(args),2)
     keys, index, vals = if n > 0
-        (args[1:2:end], ntuple(n, identity), Any[args[2:2:end]...])
+        (args[1:2:end], ntuple(identity, n), Any[args[2:2:end]...])
     else
         ((), (), Array(Any, 0))
     end


### PR DESCRIPTION
It looks like most of #10 is already in master now, but not this bit.